### PR TITLE
Fix issue 178

### DIFF
--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/plugins/events/EventsListener.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/plugins/events/EventsListener.java
@@ -552,7 +552,7 @@ public class EventsListener implements EventListener {
 
     for (int i = 0, l = elementEvents.length(); i < l; i++) {
       BindFunction listener = elementEvents.get(i);
-      if (listener.hasEventType(etype)
+      if (listener != null && listener.hasEventType(etype)
           && (originalEventType == null || originalEventType
               .equals(listener.getOriginalEventType()))) {
         if (!listener.fire(event)) {


### PR DESCRIPTION
Fix issue 178 : https://code.google.com/p/gwtquery/issues/detail?id=178

When we iterate trough listeners associated to an element for an event, it's possible that a listener removes the others and elementEvents.get(i) can return null
