### PR TITLE
Make samples be able to [$ mvn gwt:run] using CLI

### DIFF
--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -38,6 +38,7 @@
                 <artifactId>gwt-maven-plugin</artifactId>
                 <version>${gwtmaven}</version>
                 <configuration>
+                    <runTarget>index.html</runTarget>
                     <logLevel>${gwt.loglevel}</logLevel>
                     <style>${gwt.outputstyle}</style>
                     <gwtVersion>${gwtversion}</gwtVersion>


### PR DESCRIPTION
Without this line, CLI would complain:
The parameters 'runTarget' for goal org.codehaus.mojo:gwt-maven-plugin:2.5.1:run are missing or invalid
