### PR TITLE
Make GQ server side not depends on gwt-servlet not gwt-dev

### DIFF
--- a/gwtquery-core/pom.xml
+++ b/gwtquery-core/pom.xml
@@ -42,6 +42,13 @@
           <classifier>sources</classifier>
           <scope>provided</scope>
         </dependency>
+        <!-- needed in server side if we don't include gwt-servlet
+             we will remove this when using elemental.json or android.json -->
+        <dependency>
+          <groupId>org.json</groupId>
+          <artifactId>json</artifactId>
+          <version>20140107</version>
+        </dependency>
     </dependencies>
     <build>
         <resources>


### PR DESCRIPTION
Adding org.json dependency since we depend on it, and 2.7
uses a rebased version of android.json. We will have this
dependency in snapshot until we replace json usage in server
side, but we have to remove before releasing gquery.
