### PR TITLE
Type safe promises prototype

### DIFF
--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/Promise.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/Promise.java
@@ -13,36 +13,38 @@
  */
 package com.google.gwt.query.client;
 
-import com.google.gwt.query.client.Function;
+import com.google.gwt.query.client.functions.Action1;
 
 /**
  * Definition of jquery Promise interface used in gquery. 
  */
-public interface Promise {
+public interface Promise<T> {
   
   /**
    * Definition of jquery Deferred interface used in gquery. 
    */
-  public interface Deferred {
+  public interface Deferred<T> {
     /**
      * Call the progressCallbacks on a Deferred object with the given args.
      */
-    Deferred notify(Object... o);
+    Deferred<T> notify(Object... o);
     
     /**
      * Return a Deferred’s Promise object.
      */
-    Promise promise();
+    Promise<T> promise();
     
     /**
      * Reject a Deferred object and call any failCallbacks with the given args.
      */
-    Deferred reject(Object... o);
+    Deferred<T> reject(Object... o);
     
     /**
      * Resolve a Deferred object and call any doneCallbacks with the given args.
      */
-    Deferred resolve(Object... o);
+    Deferred<T> resolve(Object... o);
+
+    Deferred<T> onResolve(T o);
   }
 
   public static final String PENDING = "pending";
@@ -58,6 +60,8 @@ public interface Promise {
    * Add handlers to be called when the Deferred object is resolved.
    */
   Promise done(Function... o);
+
+  Promise<T> done(Action1<T> doneAction);
 
   /**
    * Add handlers to be called when the Deferred object is rejected.
@@ -100,12 +104,12 @@ public interface Promise {
    *   3rd one will be called when progress notifications are sent.  
    */
   Promise then(Function... f);
-  
+
   /**
    * Add filters to be called just in case the Deferred object is rejected returning
    * a new valid promise so as we can continue the flow control of the chain.
    *
-   * It works in the same way than adding a second parameter to {@link then} method but 
+   * It works in the same way than adding a second parameter to {@link #then} method but
    * continuing the flow and making more readable the code.
    *
    * Example:
@@ -122,7 +126,7 @@ public interface Promise {
   /**
    * Add filters to be called just in case the Deferred object is resolved.
    *
-   * It works in the same way than {@link then} does but making more readable
+   * It works in the same way than {@link #then} does but making more readable
    * the code flow.
    *
    * NOTE: this method is in gQuery but not in jQuery.

--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/functions/Action.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/functions/Action.java
@@ -1,0 +1,3 @@
+package com.google.gwt.query.client.functions;
+
+public interface Action extends Func {}

--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/functions/Action0.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/functions/Action0.java
@@ -1,0 +1,5 @@
+package com.google.gwt.query.client.functions;
+
+public interface Action0 extends Action {
+  public void call();
+}

--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/functions/Action1.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/functions/Action1.java
@@ -1,0 +1,5 @@
+package com.google.gwt.query.client.functions;
+
+public interface Action1<T1> extends Action {
+  public void call(T1 t1);
+}

--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/functions/Action2.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/functions/Action2.java
@@ -1,0 +1,7 @@
+package com.google.gwt.query.client.functions;
+
+import com.google.gwt.query.client.functions.Action;
+
+public interface Action2<T1, T2> extends Action {
+  public void call(T1 t1, T2 t2);
+}

--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/functions/Action3.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/functions/Action3.java
@@ -1,0 +1,7 @@
+package com.google.gwt.query.client.functions;
+
+import com.google.gwt.query.client.functions.Action;
+
+public interface Action3<T1, T2, T3> extends Action {
+  public void call(T1 t1, T2 t2, T3 t3);
+}

--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/functions/Func.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/functions/Func.java
@@ -1,0 +1,3 @@
+package com.google.gwt.query.client.functions;
+
+public interface Func {}

--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/functions/Func0.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/functions/Func0.java
@@ -1,0 +1,5 @@
+package com.google.gwt.query.client.functions;
+
+public interface Func0<R> extends Func {
+  public R call();
+}

--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/functions/Func1.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/functions/Func1.java
@@ -1,0 +1,5 @@
+package com.google.gwt.query.client.functions;
+
+public interface Func1<T1, R> extends Func {
+  public R call(T1 t1);
+}

--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/functions/Func2.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/functions/Func2.java
@@ -1,0 +1,5 @@
+package com.google.gwt.query.client.functions;
+
+public interface Func2<T1, T2, R> extends Func {
+  public R call(T1 t1, T2 t2);
+}

--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/functions/Func3.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/functions/Func3.java
@@ -1,0 +1,5 @@
+package com.google.gwt.query.client.functions;
+
+public interface Func3<T1, T2, T3, R> extends Func {
+  public R call(T1 t1, T2 t2, T3 t3);
+}

--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/functions/FuncN.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/functions/FuncN.java
@@ -1,0 +1,5 @@
+package com.google.gwt.query.client.functions;
+
+public interface FuncN<R> extends Func {
+  public R call(Object... args);
+}

--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/functions/Functions.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/functions/Functions.java
@@ -1,0 +1,309 @@
+package com.google.gwt.query.client.functions;
+
+import com.google.gwt.query.client.Function;
+
+public class Functions {
+
+  /**
+   * Converts a {@link Func0} to a {@link FuncN} to allow heterogeneous handling of functions with different
+   * arities.
+   *
+   * @param f
+   *          the {@code Func0} to convert
+   * @return a {@link FuncN} representation of {@code f}
+   */
+  public static <R> FuncN<R> fromFunc(final Func0<? extends R> f) {
+    return new FuncN<R>() {
+
+      @Override
+      public R call(Object... args) {
+        if (args.length != 0) {
+          throw new RuntimeException("Func0 expecting 0 arguments.");
+        }
+        return f.call();
+      }
+
+    };
+  }
+
+  /**
+   * Converts a {@link Func1} to a {@link FuncN} to allow heterogeneous handling of functions with different
+   * arities.
+   *
+   * @param f
+   *          the {@code Func1} to convert
+   * @return a {@link FuncN} representation of {@code f}
+   */
+  public static <T0, R> FuncN<R> fromFunc(final Func1<? super T0, ? extends R> f) {
+    return new FuncN<R>() {
+
+      @SuppressWarnings("unchecked")
+      @Override
+      public R call(Object... args) {
+        if (args.length != 1) {
+          throw new RuntimeException("Func1 expecting 1 argument.");
+        }
+        return f.call((T0) args[0]);
+      }
+
+    };
+  }
+
+  /**
+   * Converts a {@link Func2} to a {@link FuncN} to allow heterogeneous handling of functions with different
+   * arities.
+   *
+   * @param f
+   *          the {@code Func2} to convert
+   * @return a {@link FuncN} representation of {@code f}
+   */
+  public static <T0, T1, R> FuncN<R> fromFunc(final Func2<? super T0, ? super T1, ? extends R> f) {
+    return new FuncN<R>() {
+
+      @SuppressWarnings("unchecked")
+      @Override
+      public R call(Object... args) {
+        if (args.length != 2) {
+          throw new RuntimeException("Func2 expecting 2 arguments.");
+        }
+        return f.call((T0) args[0], (T1) args[1]);
+      }
+
+    };
+  }
+
+  /**
+   * Converts a {@link Func3} to a {@link FuncN} to allow heterogeneous handling of functions with different
+   * arities.
+   *
+   * @param f
+   *          the {@code Func3} to convert
+   * @return a {@link FuncN} representation of {@code f}
+   */
+  public static <T0, T1, T2, R> FuncN<R> fromFunc(final Func3<? super T0, ? super T1, ? super T2, ? extends R> f) {
+    return new FuncN<R>() {
+
+      @SuppressWarnings("unchecked")
+      @Override
+      public R call(Object... args) {
+        if (args.length != 3) {
+          throw new RuntimeException("Func3 expecting 3 arguments.");
+        }
+        return f.call((T0) args[0], (T1) args[1], (T2) args[2]);
+      }
+
+    };
+  }
+
+  /**
+   * Converts an {@link Action0} to a {@link FuncN} to allow heterogeneous handling of functions with
+   * different arities.
+   *
+   * @param f
+   *          the {@code Action0} to convert
+   * @return a {@link FuncN} representation of {@code f}
+   */
+  public static FuncN<Void> fromAction(final Action0 f) {
+    return new FuncN<Void>() {
+
+      @Override
+      public Void call(Object... args) {
+        if (args.length != 0) {
+          throw new RuntimeException("Action0 expecting 0 arguments.");
+        }
+        f.call();
+        return null;
+      }
+
+    };
+  }
+
+  /**
+   * Converts an {@link Action1} to a {@link FuncN} to allow heterogeneous handling of functions with
+   * different arities.
+   *
+   * @param f
+   *          the {@code Action1} to convert
+   * @return a {@link FuncN} representation of {@code f}
+   */
+  public static <T0> FuncN<Void> fromAction(final Action1<? super T0> f) {
+    return new FuncN<Void>() {
+
+      @SuppressWarnings("unchecked")
+      @Override
+      public Void call(Object... args) {
+        if (args.length != 1) {
+          throw new RuntimeException("Action1 expecting 1 argument.");
+        }
+        f.call((T0) args[0]);
+        return null;
+      }
+
+    };
+  }
+
+  /**
+   * Converts an {@link Action2} to a {@link FuncN} to allow heterogeneous handling of functions with
+   * different arities.
+   *
+   * @param f
+   *          the {@code Action2} to convert
+   * @return a {@link FuncN} representation of {@code f}
+   */
+  public static <T0, T1> FuncN<Void> fromAction(final Action2<? super T0, ? super T1> f) {
+    return new FuncN<Void>() {
+
+      @SuppressWarnings("unchecked")
+      @Override
+      public Void call(Object... args) {
+        if (args.length != 2) {
+          throw new RuntimeException("Action3 expecting 2 arguments.");
+        }
+        f.call((T0) args[0], (T1) args[1]);
+        return null;
+      }
+
+    };
+  }
+
+  /**
+   * Converts an {@link Action3} to a {@link FuncN} to allow heterogeneous handling of functions with
+   * different arities.
+   *
+   * @param f
+   *          the {@code Action3} to convert
+   * @return a {@link FuncN} representation of {@code f}
+   */
+  public static <T0, T1, T2> FuncN<Void> fromAction(final Action3<? super T0, ? super T1, ? super T2> f) {
+    return new FuncN<Void>() {
+
+      @SuppressWarnings("unchecked")
+      @Override
+      public Void call(Object... args) {
+        if (args.length != 3) {
+          throw new RuntimeException("Action3 expecting 3 arguments.");
+        }
+        f.call((T0) args[0], (T1) args[1], (T2) args[2]);
+        return null;
+      }
+
+    };
+  }
+
+  public static <R> Function fromFuncN(final FuncN<R> f) {
+    return new Function() {
+      @Override
+      public Object f(Object... args) {
+        return f.call(args);
+      }
+    };
+  }
+
+  /**
+   * Constructs a predicate that returns true for each input for which the source predicate returns false, and
+   * vice versa.
+   *
+   * @param predicate
+   *            the source predicate to negate
+   * @return a function that returns a Boolean that represents an inversion of the logical effect of
+   *         {@code predicate}
+   */
+  public static <T> Func1<T, Boolean> not(Func1<? super T, Boolean> predicate) {
+    return new Not<T>(predicate);
+  }
+
+  /**
+   * Returns a function that always returns {@code true}.
+   *
+   * @return a {@link Func1} that accepts an Object and returns the Boolean {@code true}
+   */
+  public static <T> Func1<? super T, Boolean> alwaysTrue() {
+    return AlwaysTrue.INSTANCE;
+  }
+
+  /**
+   * Returns a function that always returns {@code false}.
+   *
+   * @return a {@link Func1} that accepts an Object and returns the Boolean {@code false}
+   */
+  public static <T> Func1<? super T, Boolean> alwaysFalse() {
+    return AlwaysFalse.INSTANCE;
+  }
+
+  /**
+   * Returns a function that always returns the Object it is passed.
+   *
+   * @return a {@link Func1} that accepts an Object and returns the same Object
+   */
+  public static <T> Func1<T, T> identity() {
+    return new Func1<T, T>() {
+      @Override
+      public T call(T o) {
+        return o;
+      }
+    };
+  }
+
+  private enum AlwaysTrue implements Func1<Object, Boolean> {
+    INSTANCE;
+
+    @Override
+    public Boolean call(Object o) {
+      return true;
+    }
+  }
+
+  private enum AlwaysFalse implements Func1<Object, Boolean> {
+    INSTANCE;
+
+    @Override
+    public Boolean call(Object o) {
+      return false;
+    }
+  }
+
+  /**
+   * Returns a function that merely returns {@code null}, without side effects.
+   *
+   * @return a function that returns {@code null}
+   */
+  @SuppressWarnings("unchecked")
+  public static <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, R> NullFunction<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, R> returnNull() {
+    return (NullFunction<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, R>) NULL_FUNCTION;
+  }
+
+  @SuppressWarnings("rawtypes")
+  private static final NullFunction NULL_FUNCTION = new NullFunction();
+
+  private static final class NullFunction<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, R> implements
+      Func0<R>,
+      Func1<T0, R>,
+      Func2<T0, T1, R>,
+      Func3<T0, T1, T2, R>,
+      FuncN<R> {
+    @Override
+    public R call() {
+      return null;
+    }
+
+    @Override
+    public R call(T0 t1) {
+      return null;
+    }
+
+    @Override
+    public R call(T0 t1, T1 t2) {
+      return null;
+    }
+
+    @Override
+    public R call(T0 t1, T1 t2, T2 t3) {
+      return null;
+    }
+
+    @Override
+    public R call(Object... args) {
+      return null;
+    }
+  }
+}

--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/functions/Not.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/functions/Not.java
@@ -1,0 +1,27 @@
+package com.google.gwt.query.client.functions;
+
+/**
+ * Implements the negation of a predicate.
+ *
+ * @param <T>
+ *            The type of the single input parameter.
+ */
+public class Not<T> implements Func1<T, Boolean> {
+  private final Func1<? super T, Boolean> predicate;
+
+  /**
+   * Constructs a predicate that returns true for each input that the source
+   * predicate returns false for and vice versa.
+   *
+   * @param predicate
+   *            The source predicate to negate.
+   */
+  public Not(Func1<? super T, Boolean> predicate) {
+    this.predicate = predicate;
+  }
+
+  @Override
+  public Boolean call(T param) {
+    return !predicate.call(param);
+  }
+}

--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/plugins/deferred/PromiseFunction.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/plugins/deferred/PromiseFunction.java
@@ -38,7 +38,7 @@ import com.google.gwt.query.client.plugins.deferred.Deferred.DeferredPromiseImpl
  *    });
  * </pre>
  */
-public abstract class PromiseFunction extends DeferredPromiseImpl {
+public abstract class PromiseFunction<T> extends DeferredPromiseImpl<T> {
   public PromiseFunction() {
     f(dfd);
   }
@@ -47,5 +47,5 @@ public abstract class PromiseFunction extends DeferredPromiseImpl {
    * This function is called once when the promise is created and the
    * new deferred is available.
    */
-  public abstract void f(Deferred dfd);
+  public abstract void f(Deferred<T> dfd);
 }

--- a/gwtquery-core/src/test/java/com/google/gwt/query/client/deferred/DeferredTest.java
+++ b/gwtquery-core/src/test/java/com/google/gwt/query/client/deferred/DeferredTest.java
@@ -15,18 +15,20 @@
  */
 package com.google.gwt.query.client.deferred;
 
-import static com.google.gwt.query.client.GQuery.*;
-
 import com.google.gwt.core.shared.GWT;
 import com.google.gwt.junit.client.GWTTestCase;
 import com.google.gwt.query.client.Function;
 import com.google.gwt.query.client.GQuery;
 import com.google.gwt.query.client.Promise.Deferred;
+import com.google.gwt.query.client.functions.Action1;
+import com.google.gwt.query.client.functions.Func2;
 import com.google.gwt.query.client.plugins.deferred.Callbacks;
 import com.google.gwt.query.client.plugins.deferred.Callbacks.Callback;
-import com.google.gwt.query.client.plugins.deferred.FunctionDeferred.CacheType;
 import com.google.gwt.query.client.plugins.deferred.FunctionDeferred;
+import com.google.gwt.query.client.plugins.deferred.FunctionDeferred.CacheType;
 import com.google.gwt.query.client.plugins.deferred.PromiseFunction;
+
+import static com.google.gwt.query.client.GQuery.when;
 
 /**
  * Tests for Deferred which can run either in JVM and GWT
@@ -197,6 +199,43 @@ public class DeferredTest extends GWTTestCase {
       done = true;
     }});
     
+    if (!GWT.isClient()) {
+      assertTrue(done);
+    }
+  }
+  
+  public void testTypedDone() {
+    done = false;
+    delayTestFinish(5000);
+
+    com.google.gwt.query.client.plugins.deferred.Deferred
+      .when(
+        new PromiseFunction<String>() {
+          public void f(Deferred<String> dfd) {
+            dfd.onResolve("Hi");
+          }
+        },
+        new PromiseFunction<Integer>() {
+          @Override
+          public void f(Deferred<Integer> dfd) {
+            dfd.onResolve(101);
+          }
+        },
+        new Func2<String, Integer, String>() {
+          @Override
+          public String call(String s, Integer integer) {
+            return s + " " + integer;
+          }
+        })
+      .done(new Action1<String>() {
+        @Override
+        public void call(String o) {
+          assertEquals("Hi 101", o);
+          finishTest();
+          done = true;
+        }
+      });
+
     if (!GWT.isClient()) {
       assertTrue(done);
     }


### PR DESCRIPTION
Discussion https://groups.google.com/forum/#!topic/gwtquery/mMey1XVkNGM

I don't add types for failures and progress because I prefer a simpler solution. Also, I propose the Zip strategy (https://github.com/ReactiveX/RxJava/blob/1.x/src/main/java/rx/Observable.java#L2639) because it's solves the problem whitout add complex generics in Promise interface.

Related project https://github.com/jdeferred/jdeferred, this project is an example of full typesafe promises. Although I think that add the failure type as generic is a bad idea (unnecessary complexity), I vote for failures to be Thorwables (reactivex strategy).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/arcbees/gwtquery/301)
<!-- Reviewable:end -->
