### PR TITLE
Improved filter performance on simple attribute selectors

### DIFF
--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/Filters.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/Filters.java
@@ -1,0 +1,42 @@
+package com.google.gwt.query.client;
+
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.regexp.shared.MatchResult;
+import com.google.gwt.regexp.shared.RegExp;
+
+public class Filters {
+
+  private static RegExp simpleAttrFilter = RegExp.compile("\\[([\\w-]+)(\\^|\\$|\\*|\\||~|!)?=?[\"']?([\\w\\u00C0-\\uFFFF\\s\\-_\\.]+)?[\"']?\\]");
+
+  /**
+   * Try to parse the selector and return an equivalent {@link Predicate}.
+   *
+   * @return the {@link Predicate} filter or null if the selector is not supported
+   */
+  public static Predicate asPredicateFilter(String selector) {
+    final MatchResult simpleAttrMatch = simpleAttrFilter.exec(selector);
+    if (simpleAttrMatch == null) return null; // non simple attr filter
+    final String attrName = simpleAttrMatch.getGroup(1);
+    final String matchOp = simpleAttrMatch.getGroup(2);
+    final String matchVal = simpleAttrMatch.getGroup(3);
+    final char op = matchOp == null || matchOp.length() == 0 ? '0' : matchOp.charAt(0);
+    if ("0=^$*|~!".indexOf(op) == -1) return null; // unsupported or illegal operator
+    return new Predicate() {
+      @Override
+      public boolean f(Element e, int index) {
+        switch (op) {
+          case '0': return e.hasAttribute(attrName);
+          case '=': return e.getAttribute(attrName).equals(matchVal);
+          case '^': return e.getAttribute(attrName).startsWith(matchVal);
+          case '$': return e.getAttribute(attrName).endsWith(matchVal);
+          case '*': return e.getAttribute(attrName).contains(matchVal);
+          case '|': return (e.getAttribute(attrName) + "-").startsWith(matchVal + "-");
+          case '~': return (" " + e.getAttribute(attrName) + " ").contains(" " + matchVal + " ");
+          case '!': return !e.getAttribute(attrName).equals(matchVal);
+          default: return false;
+        }
+      }
+    };
+  }
+
+}

--- a/gwtquery-core/src/test/java/com/google/gwt/query/client/GQueryCoreTestGwt.java
+++ b/gwtquery-core/src/test/java/com/google/gwt/query/client/GQueryCoreTestGwt.java
@@ -1301,7 +1301,7 @@ public class GQueryCoreTestGwt extends GWTTestCase {
      assertEquals(3, $inner.filter("div").length());
   }
 
-  public void testFilterMethodWithSimpleAttrShortcut(){
+  public void testFilterMethodAsPredicateFilter() {
     // first test filter on element attached to the DOM
     String content = "" +
       "<div>" +
@@ -1318,15 +1318,24 @@ public class GQueryCoreTestGwt extends GWTTestCase {
 
     $(e).html(content);
 
-    assertEquals(10, $("*", e).length());
-    assertEquals(1, $("*", e).filter("[data-exists]").length());
-    assertEquals(1, $("*", e).filter("[data-equal='val']").length());
-    assertEquals(1, $("*", e).filter("[data-starts-with^='v']").length());
-    assertEquals(1, $("*", e).filter("[data-ends-with$='l']").length());
-    assertEquals(1, $("*", e).filter("[data-contains*='a']").length());
-    assertEquals(1, $("*", e).filter("[data-hyphen|='val']").length());
-    assertEquals(1, $("*", e).filter("[data-word~='val']").length());
-    assertEquals(9, $("*", e).filter("[data-not!='val']").length());
+    final List<Predicate> predicates = new ArrayList<Predicate>();
+    final GQuery $ = new GQuery($("*", e)) {
+      @Override
+      public GQuery filter(Predicate filterFn) {
+        predicates.add(filterFn);
+        return super.filter(filterFn);
+      }
+    };
+    assertEquals(10, $.length());
+    assertEquals(1, $.filter("[data-exists]").length());
+    assertEquals(1, $.filter("[data-equal='val']").length());
+    assertEquals(1, $.filter("[data-starts-with^='v']").length());
+    assertEquals(1, $.filter("[data-ends-with$='l']").length());
+    assertEquals(1, $.filter("[data-contains*='a']").length());
+    assertEquals(1, $.filter("[data-hyphen|='val']").length());
+    assertEquals(1, $.filter("[data-word~='val']").length());
+    assertEquals(9, $.filter("[data-not!='val']").length());
+    assertEquals(8, predicates.size());
 
     // second test filter on element non attached to the DOM
     GQuery $html = $("<div data=val>div1</div><div data=val>div2</div><div data=val>div3</div><span>span1</span>");


### PR DESCRIPTION
I have a listener on the body filtered by a data attribute to create advanced tooltips. I use this patch to fix the performance problem (https://github.com/ArcBees/gwtquery/issues/177). I think that this filters on attributes are quite common for delegated event listeners, and this pull-request solves in a simple way the performance problem in this situation.
