### PR TITLE
Events listener using Predicate selectors instead of cssSelectors

### DIFF
--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/GQuery.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/GQuery.java
@@ -1461,6 +1461,32 @@ public class GQuery implements Lazy<GQuery, LazyGQuery> {
 
   }
 
+  public GQuery closest(Predicate predicate, Node context) {
+    assert predicate != null;
+
+    if (context == null) {
+      context = currentContext;
+    }
+
+    JsNodeArray result = JsNodeArray.create();
+
+    for (Element e : elements) {
+      Element current = e;
+      while (current != null && current.getOwnerDocument() != null && current != context) {
+        boolean match = predicate.f(current, 0);
+        if (match) {
+          result.addNode(current);
+          break;
+        } else {
+          current = current.getParentElement();
+        }
+      }
+    }
+
+    return $(unique(result));
+
+  }
+
   /**
    * Returns a {@link Map} object as key a selector and as value the list of ancestor elements
    * matching this selectors, beginning at the first matched element and progressing up through the

--- a/gwtquery-core/src/test/java/com/google/gwt/query/client/GQueryEventsTestGwt.java
+++ b/gwtquery-core/src/test/java/com/google/gwt/query/client/GQueryEventsTestGwt.java
@@ -567,6 +567,27 @@ public class GQueryEventsTestGwt extends GWTTestCase {
 
   }
 
+  public void testLiveWithEventBitPredicate() {
+    $(e).html("<div id='div1'><div id='div2'>Content 1<span id='span1'> blop</span></div></div>");
+
+    EventsListener.getInstance(e).live(Event.ONCLICK, null, null, null, new Predicate() {
+      @Override
+      public boolean f(Element e, int index) {
+        return e.getClassName().contains("clickable");
+      }
+    }, null, new Function() {
+      public void f(Element e) {
+        $(e).css(CSS.COLOR.with(RGBColor.RED));
+      }
+    });
+
+    $("#div1", e).addClass("clickable");
+    $("#span1", e).click();
+
+    assertEquals("red", $("#div1", e).css(CSS.COLOR, false));
+
+  }
+
   public void testLiveWithMultipleEvent() {
 
     $(e).html("<div id='div1'><div id='div2'>Content 1<span id='span1'> blop</span></div></div>");


### PR DESCRIPTION
I add this strategy to avoid the performance problem https://github.com/ArcBees/gwtquery/issues/177, although I end up using the alternative solution https://github.com/ArcBees/gwtquery/pull/302.

Anyway, this path might be useful for some situations where the user want a programmatic filtering on event listeners.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/arcbees/gwtquery/303)
<!-- Reviewable:end -->
