### PR TITLE
Reuse the same document style implementation.

### DIFF
--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/GQuery.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/GQuery.java
@@ -651,7 +651,7 @@ public class GQuery implements Lazy<GQuery, LazyGQuery> {
 
   protected static DocumentStyleImpl getStyleImpl() {
     if (styleImpl == null) {
-      styleImpl = GWT.create(DocumentStyleImpl.class);
+      styleImpl = getSelectorEngine().getDocumentStyleImpl();
     }
     return styleImpl;
   }

--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/impl/AttributeImpl.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/impl/AttributeImpl.java
@@ -16,8 +16,8 @@ package com.google.gwt.query.client.impl;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.InputElement;
 import com.google.gwt.query.client.GQuery;
-import com.google.gwt.query.client.js.JsRegexp;
 import com.google.gwt.query.client.js.JsUtils;
+import com.google.gwt.regexp.shared.RegExp;
 
 /**
  * Helper class for setting and getting attribute on an element.
@@ -128,7 +128,7 @@ public class AttributeImpl {
    */
   private static class TypeAttrSetter extends DefaultSetter {
     private static AttributeSetter INSTANCE;
-    private static JsRegexp NOT_AUTHORIZED_NODE = new JsRegexp(
+    private static RegExp NOT_AUTHORIZED_NODE = RegExp.compile(
         "^(?:button|input)$", "i");
 
     public static AttributeSetter getInstance() {
@@ -161,7 +161,7 @@ public class AttributeImpl {
     }
   }
 
-  private static final JsRegexp BOOLEAN_ATTR_REGEX = new JsRegexp(
+  private static final RegExp BOOLEAN_ATTR_REGEX = RegExp.compile(
       "^(?:autofocus|autoplay|async|checked|controls|defer|disabled|hidden|loop|multiple|open|readonly|required|scoped|selected)$",
       "i");
 
@@ -198,7 +198,7 @@ public class AttributeImpl {
     }
   }
 
-  protected Object fixValue(String key, Object value) {
+  protected Object fixValue(@SuppressWarnings("unused") String key, Object value) {
     return value;
   }
 

--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/impl/DocumentStyleImpl.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/impl/DocumentStyleImpl.java
@@ -22,8 +22,8 @@ import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.Node;
 import com.google.gwt.query.client.GQuery;
 import com.google.gwt.query.client.js.JsNamedArray;
-import com.google.gwt.query.client.js.JsRegexp;
 import com.google.gwt.query.client.js.JsUtils;
+import com.google.gwt.regexp.shared.RegExp;
 import com.google.gwt.user.client.DOM;
 
 /**
@@ -31,8 +31,8 @@ import com.google.gwt.user.client.DOM;
  */
 public class DocumentStyleImpl {
 
-  private static final JsRegexp cssNumberRegex = new JsRegexp("^(fillOpacity|fontWeight|lineHeight|opacity|orphans|widows|zIndex|zoom)$", "i");
-  private static final JsRegexp sizeRegex = new JsRegexp("^(client|offset|)(width|height)$", "i");
+  private static final RegExp cssNumberRegex = RegExp.compile("^(fillOpacity|fontWeight|lineHeight|opacity|orphans|widows|zIndex|zoom)$", "i");
+  private static final RegExp sizeRegex = RegExp.compile("^(client|offset|)(width|height)$", "i");
 
 
   /**

--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/impl/SelectorEngine.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/impl/SelectorEngine.java
@@ -290,4 +290,11 @@ public class SelectorEngine implements HasSelector {
   public static native boolean hasXpathEvaluate() /*-{
     return !!$doc.evaluate;
   }-*/;
+
+  /**
+   * Return the DocumentStyleImpl used by this selector engine.
+   */
+  public DocumentStyleImpl getDocumentStyleImpl() {
+    return styleImpl;
+  }
 }


### PR DESCRIPTION
This facilitates customized filters and selectors.

As a bonus removed a couple of deprecated use of JsRegexp
