### PR TITLE
Make checkstyle run when validating sources

### DIFF
--- a/gwtquery-core/pom.xml
+++ b/gwtquery-core/pom.xml
@@ -148,10 +148,21 @@
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-checkstyle-plugin</artifactId>
-              <version>2.13</version>
               <configuration>
                 <configLocation>src/main/code-style/gwt-checkstyle.xml</configLocation>
               </configuration>
+              <executions>
+                <execution>
+                  <id>checkstyle</id>
+                  <phase>validate</phase>
+                  <goals>
+                    <goal>check</goal>
+                  </goals>
+                  <configuration>
+                    <failOnViolation>true</failOnViolation>
+                  </configuration>
+                 </execution>
+               </executions>
             </plugin>
         </plugins>
     </build>

--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/GQuery.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/GQuery.java
@@ -13,8 +13,6 @@
  */
 package com.google.gwt.query.client;
 
-import static com.google.gwt.query.client.GQuery.$;
-import static com.google.gwt.query.client.GQuery.document;
 import static com.google.gwt.query.client.plugins.QueuePlugin.Queue;
 
 import com.google.gwt.core.client.GWT;


### PR DESCRIPTION
Just enable check-style plugin so as TC can alert about styling issues.