### PR TITLE
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding

### DIFF
--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/GQuery.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/GQuery.java
@@ -4744,7 +4744,7 @@ public class GQuery implements Lazy<GQuery, LazyGQuery> {
       } else if ("input".equalsIgnoreCase(name)) {
         InputElement ie = InputElement.as(e);
         String type = ie.getType();
-        if ("radio".equalsIgnoreCase((type)) || "checkbox".equalsIgnoreCase(type)) {
+        if ("radio".equalsIgnoreCase(type) || "checkbox".equalsIgnoreCase(type)) {
           ie.setChecked(false);
           for (String v : values) {
             if (ie.getValue().equals(v)) {

--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/impl/DocumentStyleImpl.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/impl/DocumentStyleImpl.java
@@ -63,11 +63,11 @@ public class DocumentStyleImpl {
     }
     String val = curCSS(elem, prop, force);
     if ("thick".equalsIgnoreCase(val)) {
-      return (5);
+      return 5;
     } else if ("medium".equalsIgnoreCase(val)) {
-      return (3);
+      return 3;
     } else if ("thin".equalsIgnoreCase(val)) {
-      return (1);
+      return 1;
     }
     if (!val.matches("^[\\d\\.]+.*$")) {
       val = curCSS(elem, prop, false);

--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/impl/research/SelectorEngineJS.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/impl/research/SelectorEngineJS.java
@@ -98,7 +98,7 @@ public class SelectorEngineJS extends SelectorEngineImpl {
       return null;
     } else {
       if (truth(pseudoValue.get(2))) { // odd or even
-        start = (eq(pseudoValue.get(2), "odd")) ? 1 : 2;
+        start = eq(pseudoValue.get(2), "odd") ? 1 : 2;
         modVal = (start == 1) ? 1 : 0;
       } else if (JsUtils
           .truth(pseudoValue.get(3))) { // single digit
@@ -214,7 +214,7 @@ public class SelectorEngineJS extends SelectorEngineImpl {
 
   private static void getGeneralSiblingNodes(JsNodeArray matchingElms,
       JsObjectArray<String> nextTag, JsRegexp nextRegExp, Node prevRef) {
-    while (JsUtils.truth((prevRef = SelectorEngine.getNextSibling(prevRef)))
+    while (JsUtils.truth(prevRef = SelectorEngine.getNextSibling(prevRef))
         && !isAdded(prevRef)) {
       if (!JsUtils.truth(nextTag) || nextRegExp
           .test(prevRef.getNodeName())) {
@@ -419,9 +419,9 @@ public class SelectorEngineJS extends SelectorEngineImpl {
                       ? attributeMatch.get(3).replaceAll("\\.", "\\.")
                       : null;
               String attrVal = attrToRegExp(attributeValue,
-                  (JsUtils.or(attributeMatch.get(2), null)));
-              regExpAttributes[q] = (JsUtils.truth(attrVal) ? new JsRegexp(
-                  attrVal) : null);
+                  JsUtils.or(attributeMatch.get(2), null));
+              regExpAttributes[q] = JsUtils.truth(attrVal) ? new JsRegexp(
+                  attrVal) : null;
               regExpAttributesStr[q] = attributeMatch.get(1);
             }
             JsNodeArray matchingAttributeElms = JsNodeArray.create();
@@ -594,11 +594,11 @@ public class SelectorEngineJS extends SelectorEngineImpl {
       previous = next = previousMatch.getElement(j);
       if (previousDir) {
         while (JsUtils
-            .truth((next = SelectorEngine.getPreviousSibling(next)))
+            .truth(next = SelectorEngine.getPreviousSibling(next))
             && next.getNodeType() != Node.ELEMENT_NODE) {
         }
       } else {
-        while (JsUtils.truth((next = SelectorEngine.getNextSibling(next)))
+        while (JsUtils.truth(next = SelectorEngine.getNextSibling(next))
             && next.getNodeType() != Node.ELEMENT_NODE) {
         }
       }

--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/js/JsObjectArray.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/js/JsObjectArray.java
@@ -38,7 +38,7 @@ public final class JsObjectArray<T> extends JavaScriptObject {
   public JsObjectArray<T> add(T... vals) {
     for (T t : vals) {
       if (t instanceof Number) {
-        c().putNumber(length(), (((Number) t).doubleValue()));
+        c().putNumber(length(), ((Number) t).doubleValue());
       } else if (t instanceof Boolean) {
         c().putBoolean(length(), (Boolean) t);
       } else {

--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/plugins/MousePlugin.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/plugins/MousePlugin.java
@@ -206,7 +206,7 @@ public abstract class MousePlugin extends UiPlugin {
     unbindOtherEvents();
     if (started) {
       started = false;
-      preventClickEvent = (event.getCurrentEventTarget() == startEvent.getCurrentEventTarget());
+      preventClickEvent = event.getCurrentEventTarget() == startEvent.getCurrentEventTarget();
       mouseStop(element, event);
     }
 

--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/plugins/UiPlugin.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/plugins/UiPlugin.java
@@ -117,8 +117,8 @@ public class UiPlugin extends GQuery {
     @Override
     protected boolean scrollParentPositionTest(UiPlugin gQueryUi) {
       String position = gQueryUi.css("position", false);
-      return ("absolute".equals(position) || "relative".equals(position) || "static"
-          .equals(position));
+      return "absolute".equals(position) || "relative".equals(position) || "static"
+          .equals(position);
     }
   }
 

--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/plugins/effects/ClipAnimation.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/plugins/effects/ClipAnimation.java
@@ -134,7 +134,7 @@ public class ClipAnimation extends PropertiesAnimation {
       return;
     }
     if (currentAction == Action.HIDE) {
-      progress = (1 - progress);
+      progress = 1 - progress;
     }
     int w = g.outerWidth();
     int h = g.outerHeight();
@@ -154,11 +154,11 @@ public class ClipAnimation extends PropertiesAnimation {
       left = (w - right) / 2;
     }
     if (corner == Corner.TOP_RIGHT || corner == Corner.BOTTOM_RIGHT) {
-      left = (w - right);
+      left = w - right;
       right = w;
     }
     if (corner == Corner.BOTTOM_LEFT || corner == Corner.BOTTOM_RIGHT) {
-      top = (h - bottom);
+      top = h - bottom;
       bottom = h;
     }
 

--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/plugins/effects/Fx.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/plugins/effects/Fx.java
@@ -268,7 +268,7 @@ public class Fx {
   }
 
   public void applyValue(GQuery g, double progress) {
-    double ret = (start + ((end - start) * progress));
+    double ret = start + ((end - start) * progress);
     String val = ("px".equals(unit) ? ((int) ret) : ret) + unit;
     if ("scrollTop".equals(cssprop)) {
       g.scrollTop((int) ret);

--- a/gwtquery-core/src/main/java/com/google/gwt/query/rebind/JsniBundleGenerator.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/rebind/JsniBundleGenerator.java
@@ -251,11 +251,11 @@ public class JsniBundleGenerator extends Generator {
           if (isJS)
             out = "\n";
         } else if (isCComment) {
-          isSlash = isCComment = !(isJS = (last == '*' && c == '/'));
+          isSlash = isCComment = !(isJS = last == '*' && c == '/');
           if (isJS)
             out = "";
         } else if (isRegex) {
-          isJS = !(isSlash = isRegex = (last == '\\' || c != '/'));
+          isJS = !(isSlash = isRegex = last == '\\' || c != '/');
           if (isJS) {
             String mod = "";
             while (++i < l) {

--- a/gwtquery-core/src/main/java/com/google/gwt/query/rebind/JsonBuilderGenerator.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/rebind/JsonBuilderGenerator.java
@@ -298,7 +298,7 @@ public class JsonBuilderGenerator extends Generator {
 
   public boolean isTypeAssignableTo(JType t, JClassType o) {
     JClassType c = t.isClassOrInterface();
-    return (c != null && c.isAssignableTo(o));
+    return c != null && c.isAssignableTo(o);
   }
 
   private void generateCreateMethod(SourceWriter sw, TreeLogger logger) {

--- a/gwtquery-core/src/main/java/com/google/gwt/query/rebind/SelectorGeneratorXPath.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/rebind/SelectorGeneratorXPath.java
@@ -238,7 +238,7 @@ public class SelectorGeneratorXPath extends SelectorGeneratorBase {
       return null;
     } else {
       if (notNull(pseudoValue.group(2))) { // odd or even
-        start = ("odd".equals(pseudoValue.group(2))) ? 1 : 2;
+        start = "odd".equals(pseudoValue.group(2)) ? 1 : 2;
         modVal = (start == 1) ? 1 : 0;
       } else if (notNull(pseudoValue.group(3))) { // single digit
         start = Integer.parseInt(pseudoValue.group(3), 10);
@@ -287,8 +287,8 @@ public class SelectorGeneratorXPath extends SelectorGeneratorBase {
     } else if ("nth".equals(pseudo[0])) {
       if (!pseudoValue.matches("^n$")) {
         String position =
-            (("last".equals(pseudo[1])) ? "(count(following-sibling::"
-                : "(count(preceding-sibling::") + tag + ") + 1)";
+            "last".equals(pseudo[1]) ? "(count(following-sibling::"
+                : "(count(preceding-sibling::" + tag + ") + 1)";
         Sequence sequence = getSequence(pseudoValue);
         if (sequence != null) {
           if (sequence.start == sequence.max) {

--- a/gwtquery-core/src/main/java/com/google/gwt/query/rebind/XmlBuilderGenerator.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/rebind/XmlBuilderGenerator.java
@@ -76,7 +76,7 @@ public class XmlBuilderGenerator extends Generator {
 
   public boolean isTypeAssignableTo(JType t, JClassType o) {
     JClassType c = t.isClassOrInterface();
-    return (c != null && c.isAssignableTo(o));
+    return c != null && c.isAssignableTo(o);
   }
 
   public void generateMethod(SourceWriter sw, JMethod method, TreeLogger logger)


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:UselessParenthesesCheck Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AUselessParenthesesCheck
Please let me know if you have any questions.
George Kankava

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/arcbees/gwtquery/374)
<!-- Reviewable:end -->
