### PR TITLE
squid:S00115 - Constant names should comply with a naming convention

### DIFF
--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/impl/SelectorEngine.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/impl/SelectorEngine.java
@@ -53,7 +53,7 @@ public class SelectorEngine implements HasSelector {
   }-*/;
 
   public NodeList<Element> querySelectorAll(String selector, Node ctx) {
-    if (!hasQuerySelector) {
+    if (!HAS_QUERY_SELECTOR) {
       return impl.select(selector, ctx);
     }
     try {
@@ -111,7 +111,7 @@ public class SelectorEngine implements HasSelector {
 
   protected Node root = Document.get();
 
-  public static final boolean hasQuerySelector = hasQuerySelectorAll();
+  public static final boolean HAS_QUERY_SELECTOR = hasQuerySelectorAll();
 
   public static JsMap<String, Predicate> filters;
 
@@ -280,7 +280,7 @@ public class SelectorEngine implements HasSelector {
   }
 
   public boolean isDegradated() {
-    return !hasQuerySelector;
+    return !HAS_QUERY_SELECTOR;
   }
 
   /**

--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/impl/SelectorEngineNative.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/impl/SelectorEngineNative.java
@@ -61,7 +61,7 @@ public class SelectorEngineNative extends SelectorEngineImpl {
       selector = xsel;
     }
 
-    if (!SelectorEngine.hasQuerySelector || selector.matches(NATIVE_EXCEPTIONS_REGEXP)) {
+    if (!SelectorEngine.HAS_QUERY_SELECTOR || selector.matches(NATIVE_EXCEPTIONS_REGEXP)) {
       return impl.select(selector, ctx);
     } else {
       try {

--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/impl/SelectorEngineNativeIE8.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/impl/SelectorEngineNativeIE8.java
@@ -33,7 +33,7 @@ public class SelectorEngineNativeIE8 extends SelectorEngineSizzleIE {
       ".*(:contains|!=|:not|:nth-|:only-|:first|:last|:even|:odd).*";
 
   public NodeList<Element> select(String selector, Node ctx) {
-    if (!SelectorEngine.hasQuerySelector || selector.matches(NATIVE_EXCEPTIONS_REGEXP)) {
+    if (!SelectorEngine.HAS_QUERY_SELECTOR || selector.matches(NATIVE_EXCEPTIONS_REGEXP)) {
       return super.select(selector, ctx);
     } else {
       try {

--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/plugins/Effects.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/plugins/Effects.java
@@ -63,7 +63,7 @@ public class Effects extends QueuePlugin<Effects> {
     }
 
     public GQAnimation setEasing(Easing ease) {
-      easing = ease != null ? ease : EasingCurve.swing;
+      easing = ease != null ? ease : EasingCurve.SWING;
       return this;
     }
 
@@ -361,7 +361,7 @@ public class Effects extends QueuePlugin<Effects> {
    * @param duration the duration in milliseconds of the animation
    */
   public Effects animate(Object stringOrProperties, int duration, Function... funcs) {
-    return animate(stringOrProperties, duration, EasingCurve.linear, funcs);
+    return animate(stringOrProperties, duration, EasingCurve.LINEAR, funcs);
   }
 
   /**

--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/plugins/effects/PropertiesAnimation.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/plugins/effects/PropertiesAnimation.java
@@ -39,12 +39,12 @@ public class PropertiesAnimation extends GQAnimation {
     /**
      * @deprecated use EasingCurve.linear instead
      */
-    Easing LINEAR = EasingCurve.linear;
+    Easing LINEAR = EasingCurve.LINEAR;
 
     /**
      * @deprecated use EasingCurve.swing instead
      */
-    Easing SWING = EasingCurve.swing;
+    Easing SWING = EasingCurve.SWING;
   }
 
   /**
@@ -70,61 +70,61 @@ public class PropertiesAnimation extends GQAnimation {
    *
    */
   public static enum EasingCurve implements Easing {
-    linear(0, 0, 1, 1) {
+    LINEAR(0, 0, 1, 1) {
       public double interpolate(double p) {
         return p;
       }
 
       public String toString() {
-        return "linear";
+        return "LINEAR";
       }
     },
-    ease(0.25, 0.1, 0.25, 1) {
+    EASE(0.25, 0.1, 0.25, 1) {
       public String toString() {
-        return "ease";
+        return "EASE";
       }
     },
-    easeIn(0.42, 0, 1, 1) {
+    EASE_IN(0.42, 0, 1, 1) {
       public String toString() {
-        return "ease-in";
+        return "EASE_IN";
       }
     },
-    easeOut(0, 0, 0.58, 1) {
+    EASE_OUT(0, 0, 0.58, 1) {
       public String toString() {
-        return "ease-out";
+        return "EASE_OUT";
       }
     },
-    easeInOut(0.42, 0, 0.58, 1) {
+    EASE_IN_OUT(0.42, 0, 0.58, 1) {
       public String toString() {
-        return "ease-in-out";
+        return "EASE_IN_OUT";
       }
     },
-    snap(0, 1, .5, 1),
-    swing(.02, .01, .47, 1),
-    easeInCubic(.550, .055, .675, .190),
-    easeOutCubic(.215, .61, .355, 1),
-    easeInOutCubic(.645, .045, .355, 1),
-    easeInCirc(.6, .04, .98, .335),
-    easeOutCirc(.075, .82, .165, 1),
-    easeInOutCirc(.785, .135, .15, .86),
-    easeInExpo(.95, .05, .795, .035),
-    easeOutExpo(.19, 1, .22, 1),
-    easeInOutExpo(1, 0, 0, 1),
-    easeInQuad(.55, .085, .68, .53),
-    easeOutQuad(.25, .46, .45, .94),
-    easeInOutQuad(.455, .03, .515, .955),
-    easeInQuart(.895, .03, .685, .22),
-    easeOutQuart(.165, .84, .44, 1),
-    easeInOutQuart(.77, 0, .175, 1),
-    easeInQuint(.755, .05, .855, .06),
-    easeOutQuint(.23, 1, .32, 1),
-    easeInOutQuint(.86, 0, .07, 1),
-    easeInSine(.47, 0, .745, .715),
-    easeOutSine(.39, .575, .565, 1),
-    easeInOutSine(.445, .05, .55, .95),
-    easeInBack(.6, -.28, .735, .045),
-    easeOutBack(.175, .885, .32, 1.275),
-    easeInOutBack(.68, -.55, .265, 1.55),
+    SNAP(0, 1, .5, 1),
+    SWING(.02, .01, .47, 1),
+    EASE_IN_CUBIC(.550, .055, .675, .190),
+    EASE_OUT_CUBIC(.215, .61, .355, 1),
+    EASE_IN_OUT_CUBIC(.645, .045, .355, 1),
+    EASE_IN_CIRC(.6, .04, .98, .335),
+    EASE_OUT_CIRC(.075, .82, .165, 1),
+    EASE_IN_OUT_CIRC(.785, .135, .15, .86),
+    EASE_IN_EXPO(.95, .05, .795, .035),
+    EASE_OUT_EXPO(.19, 1, .22, 1),
+    EASE_IN_OUT_EXPO(1, 0, 0, 1),
+    EASE_IN_QUAD(.55, .085, .68, .53),
+    EASE_OUT_QUAD(.25, .46, .45, .94),
+    EASE_IN_OUT_QUAD(.455, .03, .515, .955),
+    EASE_IN_QUART(.895, .03, .685, .22),
+    EASE_OUT_QUART(.165, .84, .44, 1),
+    EASE_IN_OUT_QUART(.77, 0, .175, 1),
+    EASE_IN_QUINT(.755, .05, .855, .06),
+    EASE_OUT_QUINT(.23, 1, .32, 1),
+    EASE_IN_OUT_QUINT(.86, 0, .07, 1),
+    EASE_IN_SINE(.47, 0, .745, .715),
+    EASE_OUT_SINE(.39, .575, .565, 1),
+    EASE_IN_OUT_SINE(.445, .05, .55, .95),
+    EASE_IN_BACK(.6, -.28, .735, .045),
+    EASE_OUT_BACK(.175, .885, .32, 1.275),
+    EASE_IN_OUT_BACK(.68, -.55, .265, 1.55),
     custom(0, 0, 1, 1);
 
     private Bezier c = new Bezier(0, 0, 1, 1);

--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/plugins/effects/Transform.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/plugins/effects/Transform.java
@@ -56,8 +56,8 @@ public class Transform  {
     }
   }
 
-  public static final String transform = vendorProperty("transform");
-  public static final String transformOrigin = vendorProperty("transformOrigin");
+  public static final String TRANSFORM_1 = vendorProperty("transform");
+  public static final String TRANSFORM_ORIGIN = vendorProperty("transformOrigin");
 
   // Non final for testing purposes.
   public static boolean has3d = supportsTransform3d();
@@ -73,12 +73,12 @@ public class Transform  {
 
   // Some browsers like HTMLUnit only support 2d transformations
   private static boolean supportsTransform3d() {
-    if (transform == null) {
+    if (TRANSFORM_1 == null) {
       return false;
     }
     String rotate = "rotateY(1deg)";
-    divStyle.setProperty(transform, rotate);
-    rotate = divStyle.getProperty(transform);
+    divStyle.setProperty(TRANSFORM_1, rotate);
+    rotate = divStyle.getProperty(TRANSFORM_1);
     return rotate != null && !rotate.isEmpty();
   }
 
@@ -124,7 +124,7 @@ public class Transform  {
     Transform t = GQuery.data(e, TRANSFORM);
     if (t == null || initial != null) {
       if (initial == null) {
-        initial = GQuery.getSelectorEngine().getDocumentStyleImpl().curCSS(e, transform, false);
+        initial = GQuery.getSelectorEngine().getDocumentStyleImpl().curCSS(e, TRANSFORM_1, false);
       }
       t = new Transform(initial);
       GQuery.data(e, TRANSFORM, t);

--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/plugins/effects/Transitions.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/plugins/effects/Transitions.java
@@ -28,9 +28,9 @@
  */
 package com.google.gwt.query.client.plugins.effects;
 
+import static com.google.gwt.query.client.plugins.effects.Transform.TRANSFORM_1;
 import static com.google.gwt.query.client.plugins.effects.Transform.getInstance;
 import static com.google.gwt.query.client.plugins.effects.Transform.isTransform;
-import static com.google.gwt.query.client.plugins.effects.Transform.transform;
 
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.query.client.Function;
@@ -73,9 +73,9 @@ public class Transitions extends Effects {
   // passing an invalid transition property in chrome, makes disable all transitions in the element
   public static final RegExp invalidTransitionNamesRegex = RegExp.compile("^(.*transform.*|duration|function|easing|delay|clip-.*)$");
 
-  protected static final String transitionEnd = browser.mozilla || browser.msie ? "transitionend" : (prefix + "TransitionEnd");
+  protected static final String TRANSITION_END = browser.mozilla || browser.msie ? "transitionend" : (prefix + "TransitionEnd");
 
-  protected static final String transition = vendorProperty("transition");
+  protected static final String TRANSITION = vendorProperty("transition");
 
   public static final Class<Transitions> Transitions = GQuery.registerPlugin(
       Transitions.class, new Plugin<Transitions>() {
@@ -86,7 +86,7 @@ public class Transitions extends Effects {
 
   private static String property(String prop) {
     if (isTransform(prop)) {
-      return transform;
+      return TRANSFORM_1;
     }
     return prop.replaceFirst("^(margin|padding).+$", "$1");
   }
@@ -98,7 +98,7 @@ public class Transitions extends Effects {
   @Override
   public String css(String prop, boolean force) {
     prop = vendorProperty(prop);
-    if (transform.equals(prop)) {
+    if (TRANSFORM_1.equals(prop)) {
       return isEmpty() ? "" : getInstance(get(0), null).toString();
     } else if (isTransform(prop)) {
       return isEmpty() ? "" : getInstance(get(0), null).get(prop);
@@ -110,16 +110,16 @@ public class Transitions extends Effects {
   @Override
   public Transitions css(String prop, String value) {
     prop = vendorProperty(prop);
-    if (transform.equals(prop)) {
+    if (TRANSFORM_1.equals(prop)) {
       for (Element e : elements()) {
         Transform t = getInstance(e, value != null ? value : "");
-        getStyleImpl().setStyleProperty(e, transform, t.toString());
+        getStyleImpl().setStyleProperty(e, TRANSFORM_1, t.toString());
       }
     } else if (isTransform(prop)) {
       for (Element e : elements()) {
         Transform t = getInstance(e, null);
         t.setFromString(prop, value);
-        getStyleImpl().setStyleProperty(e, transform, t.toString());
+        getStyleImpl().setStyleProperty(e, TRANSFORM_1, t.toString());
       }
     } else {
       super.css(prop, value);

--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/plugins/effects/TransitionsAnimation.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/plugins/effects/TransitionsAnimation.java
@@ -250,7 +250,7 @@ public class TransitionsAnimation extends PropertiesAnimation {
 
   @Override
   public void onComplete() {
-    t.css(Transitions.transition, oldTransitionValue);
+    t.css(Transitions.TRANSITION, oldTransitionValue);
     super.onComplete();
   }
 
@@ -267,7 +267,7 @@ public class TransitionsAnimation extends PropertiesAnimation {
     p = getFxProperties(false);
 
     // Save old transition value
-    oldTransitionValue = t.css(Transitions.transition);
+    oldTransitionValue = t.css(Transitions.TRANSITION);
 
     // Set new transition value
     String newTransitionValue  = "";
@@ -276,7 +276,7 @@ public class TransitionsAnimation extends PropertiesAnimation {
     for (String s : transProps) {
       newTransitionValue += (newTransitionValue.isEmpty() ? "" : ", ") + s + " " + attribs;
     }
-    t.css(Transitions.transition, newTransitionValue);
+    t.css(Transitions.TRANSITION, newTransitionValue);
 
     // Set new css properties so as the element is animated
     t.css(p);

--- a/gwtquery-core/src/main/java/com/google/gwt/query/rebind/SelectorGeneratorJSOptimal.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/rebind/SelectorGeneratorJSOptimal.java
@@ -42,9 +42,9 @@ public class SelectorGeneratorJSOptimal extends SelectorGeneratorBase {
 
   protected static Pattern nonSpace = Pattern.compile("\\S/");
 
-  protected static final String trimReStr = "^\\s+|\\s+$";
+  protected static final String TRIM_RE_STR = "^\\s+|\\s+$";
 
-  protected static Pattern trimRe = Pattern.compile(trimReStr);
+  protected static Pattern trimRe = Pattern.compile(TRIM_RE_STR);
 
   protected static Pattern tplRe = Pattern.compile("\\{(\\d+)\\}");
 

--- a/gwtquery-core/src/test/java/com/google/gwt/query/client/GQueryEffectsTestGwt.java
+++ b/gwtquery-core/src/test/java/com/google/gwt/query/client/GQueryEffectsTestGwt.java
@@ -136,10 +136,10 @@ public class GQueryEffectsTestGwt extends GWTTestCase {
 
     final int duration = 1000;
     g.as(Effects).
-        animate($$("left: '+=100'"), duration, EasingCurve.linear).
-        animate($$("top: '+=100'"), duration, EasingCurve.linear).
-        animate($$("left: '-=100'"), duration, EasingCurve.linear).
-        animate($$("top: '-=100'"), duration, EasingCurve.linear);
+        animate($$("left: '+=100'"), duration, EasingCurve.LINEAR).
+        animate($$("top: '+=100'"), duration, EasingCurve.LINEAR).
+        animate($$("left: '-=100'"), duration, EasingCurve.LINEAR).
+        animate($$("top: '-=100'"), duration, EasingCurve.LINEAR);
 
     // Configure the max duration for this test
     delayTestFinish(duration * 4);
@@ -272,7 +272,7 @@ public class GQueryEffectsTestGwt extends GWTTestCase {
             .toString());
 
     prop1 = GQuery.$$("marginTop: '-110px', marginLeft: '-110px', top: '50%', left: '50%', width: '174px', height: '174px', padding: '20px'");
-    GQAnimation an = new PropertiesAnimation().setEasing(EasingCurve.swing).setElement(g.get(0)).setProperties(prop1);
+    GQAnimation an = new PropertiesAnimation().setEasing(EasingCurve.SWING).setElement(g.get(0)).setProperties(prop1);
     an.run(0);
 
     assertEquals("cssprop=marginTop value=0 start=-110 end=0 unit=px",
@@ -297,7 +297,7 @@ public class GQueryEffectsTestGwt extends GWTTestCase {
             .toString());
 
     prop1 = GQuery.$$("marginTop: '0', marginLeft: '0', top: '0%', left: '0%', width: '100px', height: '100px', padding: '5px'");
-    an = new PropertiesAnimation().setEasing(EasingCurve.swing).setElement(g.get(0)).setProperties(prop1);
+    an = new PropertiesAnimation().setEasing(EasingCurve.SWING).setElement(g.get(0)).setProperties(prop1);
     an.run(0);
 
     assertEquals("cssprop=marginTop value=-110px start=0 end=-110 unit=px",
@@ -508,7 +508,7 @@ public class GQueryEffectsTestGwt extends GWTTestCase {
     delayTestFinish(duration * 3);
 
     g.as(Effects).
-        animate($$("$width: +=100; $border: +=4"), duration, EasingCurve.linear);
+        animate($$("$width: +=100; $border: +=4"), duration, EasingCurve.LINEAR);
 
     final Timer timer = new Timer() {
       public void run() {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S00115 Constant names should comply with a naming convention.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS00115
Please let me know if you have any questions.
George Kankava

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/arcbees/gwtquery/375)
<!-- Reviewable:end -->
