### PR TITLE
squid:S1192 String literals should not be duplicated

### DIFF
--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/GQuery.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/GQuery.java
@@ -76,6 +76,14 @@ import java.util.List;
  */
 public class GQuery implements Lazy<GQuery, LazyGQuery> {
 
+  private static final String WIDTH = "width";
+  private static final String SELECT = "select";
+  private static final String KEY_IS_NULL = "Key is null";
+  private static final String POSITION = "position";
+  private static final String HEIGHT = "height";
+  private static final String FILTER = "filter";
+  private static final String DISPLAY = "display";
+
   private enum DomMan {
     AFTER, APPEND, BEFORE, PREPEND;
   }
@@ -169,7 +177,7 @@ public class GQuery implements Lazy<GQuery, LazyGQuery> {
 
   private static final String OLD_DATA_PREFIX = "old-";
 
-  private static final String OLD_DISPLAY = OLD_DATA_PREFIX + "display";
+  private static final String OLD_DISPLAY = OLD_DATA_PREFIX + DISPLAY;
 
   private static JsMap<Class<? extends GQuery>, Plugin<? extends GQuery>> plugins;
 
@@ -2247,7 +2255,7 @@ public class GQuery implements Lazy<GQuery, LazyGQuery> {
    */
   public GQuery filter(Predicate filterFn) {
     JsNodeArray result = getSelectorEngine().filter(nodeList, filterFn).cast();
-    return pushStack(result, "filter", currentSelector);
+    return pushStack(result, FILTER, currentSelector);
   }
 
   /**
@@ -2259,7 +2267,7 @@ public class GQuery implements Lazy<GQuery, LazyGQuery> {
   public GQuery filter(String... filters) {
     String selector = join(", ", filters);
     JsNodeArray result = getSelectorEngine().filter(nodeList, selector).cast();
-    return pushStack(result, "filter", selector);
+    return pushStack(result, FILTER, selector);
   }
 
   /**
@@ -2271,7 +2279,7 @@ public class GQuery implements Lazy<GQuery, LazyGQuery> {
   public GQuery filter(boolean filterDetached, String... filters) {
     String selector = join(", ", filters);
     JsNodeArray result = getSelectorEngine().filter(nodeList, selector, filterDetached).cast();
-    return pushStack(result, "filter", selector);
+    return pushStack(result, FILTER, selector);
   }
 
   /**
@@ -2285,7 +2293,7 @@ public class GQuery implements Lazy<GQuery, LazyGQuery> {
       return this;
     }
     JsNodeArray result = getSelectorEngine().filter(nodeList, selector, filterDetached).cast();
-    return pushStack(result, "filter", selector);
+    return pushStack(result, FILTER, selector);
   }
 
   /**
@@ -2435,7 +2443,7 @@ public class GQuery implements Lazy<GQuery, LazyGQuery> {
    * margin, padding nor border.
    */
   public int height() {
-    return (int) cur("height", true);
+    return (int) cur(HEIGHT, true);
   }
 
   /**
@@ -2443,7 +2451,7 @@ public class GQuery implements Lazy<GQuery, LazyGQuery> {
    */
   public GQuery height(int height) {
     for (Element e : elements) {
-      e.getStyle().setPropertyPx("height", height);
+      e.getStyle().setPropertyPx(HEIGHT, height);
     }
     return this;
   }
@@ -2453,7 +2461,7 @@ public class GQuery implements Lazy<GQuery, LazyGQuery> {
    * units Example: $(".a").height("100%")
    */
   public GQuery height(String height) {
-    return css("height", height);
+    return css(HEIGHT, height);
   }
 
   /**
@@ -2461,7 +2469,7 @@ public class GQuery implements Lazy<GQuery, LazyGQuery> {
    */
   public GQuery hide() {
     for (Element e : elements) {
-      String currentDisplay = getStyleImpl().curCSS(e, "display", false);
+      String currentDisplay = getStyleImpl().curCSS(e, DISPLAY, false);
       Object old = data(e, OLD_DISPLAY, null);
       if (old == null && currentDisplay.length() != 0 && !"none".equals(currentDisplay)) {
         data(e, OLD_DISPLAY, currentDisplay);
@@ -3147,9 +3155,9 @@ public class GQuery implements Lazy<GQuery, LazyGQuery> {
     for (Element element : elements()) {
       GQuery g = $(element);
 
-      String position = g.css("position", true);
-      if ("static".equals(position)) {
-        css("position", "relative");
+      String positionLocal = g.css(POSITION, true);
+      if ("static".equals(positionLocal)) {
+        css(POSITION, "relative");
       }
 
       Offset curOffset = g.offset();
@@ -3158,7 +3166,7 @@ public class GQuery implements Lazy<GQuery, LazyGQuery> {
       long curTop = 0;
       long curLeft = 0;
 
-      if (("absolute".equals(position) || "fixed".equals(position))
+      if (("absolute".equals(positionLocal) || "fixed".equals(positionLocal))
           && ("auto".equals(curCSSTop) || "auto".equals(curCSSLeft))) {
         Offset curPosition = g.position();
         curTop = curPosition.top;
@@ -3198,7 +3206,7 @@ public class GQuery implements Lazy<GQuery, LazyGQuery> {
     Element offParent = JsUtils.or(get(0).getOffsetParent(), body);
     while (offParent != null && !"body".equalsIgnoreCase(offParent.getTagName())
         && !"html".equalsIgnoreCase(offParent.getTagName())
-        && "static".equals(getStyleImpl().curCSS(offParent, "position", true))) {
+        && "static".equals(getStyleImpl().curCSS(offParent, POSITION, true))) {
       offParent = offParent.getOffsetParent();
     }
     return new GQuery(offParent);
@@ -3655,7 +3663,7 @@ public class GQuery implements Lazy<GQuery, LazyGQuery> {
    *        it returns null.
    */
   public <T> T prop(String key) {
-    assert key != null : "Key is null";
+    assert key != null : KEY_IS_NULL;
     return isEmpty() ? null : JsUtils.<T> prop(get(0), key);
   }
 
@@ -3670,7 +3678,7 @@ public class GQuery implements Lazy<GQuery, LazyGQuery> {
    *        In the case of the property is undefined it returns null.
    */
   public <T> T prop(String key, Class<? extends T> clz) {
-    assert key != null : "Key is null";
+    assert key != null : KEY_IS_NULL;
     return isEmpty() ? null : JsUtils.<T> prop(get(0), key, clz);
   }
 
@@ -3685,7 +3693,7 @@ public class GQuery implements Lazy<GQuery, LazyGQuery> {
    *
    */
   public GQuery prop(String key, Object value) {
-    assert key != null : "Key is null";
+    assert key != null : KEY_IS_NULL;
 
     for (Element e : elements) {
       JsUtils.prop(e, key, value);
@@ -3709,7 +3717,7 @@ public class GQuery implements Lazy<GQuery, LazyGQuery> {
    *
    */
   public GQuery prop(String key, Function closure) {
-    assert key != null : "Key is null";
+    assert key != null : KEY_IS_NULL;
     assert closure != null : "Closure is null";
 
     int i = 0;
@@ -4189,7 +4197,7 @@ public class GQuery implements Lazy<GQuery, LazyGQuery> {
   }
 
   public GQuery select() {
-    return as(Events).triggerHtmlEvent("select");
+    return as(Events).triggerHtmlEvent(SELECT);
   }
 
   private GQuery select(String selector, Node context) {
@@ -4236,7 +4244,7 @@ public class GQuery implements Lazy<GQuery, LazyGQuery> {
 
       // reset the display
       if (oldDisplay == null && "none".equals(currentDisplay)) {
-        getStyleImpl().setStyleProperty(e, "display", "");
+        getStyleImpl().setStyleProperty(e, DISPLAY, "");
         currentDisplay = "";
       }
 
@@ -4254,7 +4262,7 @@ public class GQuery implements Lazy<GQuery, LazyGQuery> {
     for (Element e : elements) {
       String currentDisplay = e.getStyle().getDisplay();
       if ("".equals(currentDisplay) || "none".equals(currentDisplay)) {
-        getStyleImpl().setStyleProperty(e, "display",
+        getStyleImpl().setStyleProperty(e, DISPLAY,
             JsUtils.or((String) data(e, OLD_DISPLAY, null), ""));
       }
     }
@@ -4727,7 +4735,7 @@ public class GQuery implements Lazy<GQuery, LazyGQuery> {
     String value = join(",", values);
     for (Element e : elements) {
       String name = e.getNodeName();
-      if ("select".equalsIgnoreCase(name)) {
+      if (SELECT.equalsIgnoreCase(name)) {
         SelectElement s = SelectElement.as(e);
         s.setSelectedIndex(-1);
         for (String v : values) {
@@ -4775,7 +4783,7 @@ public class GQuery implements Lazy<GQuery, LazyGQuery> {
   public String[] vals() {
     if (!isEmpty()) {
       Element e = get(0);
-      if (e.getNodeName().equalsIgnoreCase("select")) {
+      if (e.getNodeName().equalsIgnoreCase(SELECT)) {
         SelectElement se = SelectElement.as(e);
         if (se.isMultiple()) {
           JsArrayString result = JsArrayString.createArray().cast();
@@ -4874,7 +4882,7 @@ public class GQuery implements Lazy<GQuery, LazyGQuery> {
    * margin, padding nor border.
    */
   public int width() {
-    return (int) cur("width", true);
+    return (int) cur(WIDTH, true);
   }
 
   /**
@@ -4882,7 +4890,7 @@ public class GQuery implements Lazy<GQuery, LazyGQuery> {
    */
   public GQuery width(int width) {
     for (Element e : elements) {
-      e.getStyle().setPropertyPx("width", width);
+      e.getStyle().setPropertyPx(WIDTH, width);
     }
     return this;
   }
@@ -4892,7 +4900,7 @@ public class GQuery implements Lazy<GQuery, LazyGQuery> {
    * units Example: $(".a").width("100%")
    */
   public GQuery width(String width) {
-    return css("width", width);
+    return css(WIDTH, width);
   }
 
   /**

--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/impl/DocumentStyleImpl.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/impl/DocumentStyleImpl.java
@@ -31,6 +31,11 @@ import com.google.gwt.user.client.DOM;
  */
 public class DocumentStyleImpl {
 
+  private static final String VISIBILITY = "visibility";
+  private static final String POSITION = "position";
+  private static final String DISPLAY = "display";
+  private static final String HEIGHT = "height";
+  private static final String WIDTH = "width";
   private static final RegExp cssNumberRegex = RegExp.compile(
       "^(fillOpacity|fontWeight|lineHeight|opacity|orphans|widows|zIndex|zoom)$", "i");
   private static final RegExp sizeRegex = RegExp.compile("^(client|offset|)(width|height)$", "i");
@@ -45,10 +50,10 @@ public class DocumentStyleImpl {
    */
   public double cur(Element elem, String prop, boolean force) {
     if (JsUtils.isWindow(elem)) {
-      if ("width".equals(prop)) {
+      if (WIDTH.equals(prop)) {
         return getContentDocument(elem).getClientWidth();
       }
-      if ("height".equals(prop)) {
+      if (HEIGHT.equals(prop)) {
         return getContentDocument(elem).getClientHeight();
       }
       elem = GQuery.body;
@@ -150,16 +155,16 @@ public class DocumentStyleImpl {
     int ret;
     if (!isVisible(e)) {
       // jquery returns the size of the element even when the element isn't visible
-      String display = curCSS(e, "display", false);
-      String position = curCSS(e, "position", false);
-      String visibility = curCSS(e, "visibility", false);
-      setStyleProperty(e, "display", "block");
-      setStyleProperty(e, "position", "absolute");
-      setStyleProperty(e, "visibility", "hidden");
+      String displayLocal = curCSS(e, DISPLAY, false);
+      String positionLocal = curCSS(e, POSITION, false);
+      String visibilityLocal = curCSS(e, VISIBILITY, false);
+      setStyleProperty(e, DISPLAY, "block");
+      setStyleProperty(e, POSITION, "absolute");
+      setStyleProperty(e, VISIBILITY, "hidden");
       ret = getSize(e, name);
-      setStyleProperty(e, "display", display);
-      setStyleProperty(e, "position", position);
-      setStyleProperty(e, "visibility", visibility);
+      setStyleProperty(e, DISPLAY, displayLocal);
+      setStyleProperty(e, POSITION, positionLocal);
+      setStyleProperty(e, VISIBILITY, visibilityLocal);
     } else {
       ret = getSize(e, name);
     }
@@ -169,18 +174,18 @@ public class DocumentStyleImpl {
   // inline elements do not have width nor height unless we set it to inline-block
   private void fixInlineElement(Element e) {
     if (e.getClientHeight() == 0 && e.getClientWidth() == 0
-        && "inline".equals(curCSS(e, "display", true))) {
-      setStyleProperty(e, "display", "inline-block");
-      setStyleProperty(e, "width", "auto");
-      setStyleProperty(e, "height", "auto");
+        && "inline".equals(curCSS(e, DISPLAY, true))) {
+      setStyleProperty(e, DISPLAY, "inline-block");
+      setStyleProperty(e, WIDTH, "auto");
+      setStyleProperty(e, HEIGHT, "auto");
     }
   }
 
   private int getSize(Element e, String name) {
     int ret = 0;
-    if ("width".equals(name)) {
+    if (WIDTH.equals(name)) {
       ret = getWidth(e);
-    } else if ("height".equals(name)) {
+    } else if (HEIGHT.equals(name)) {
       ret = getHeight(e);
     } else if ("clientWidth".equals(name)) {
       ret = e.getClientWidth();
@@ -272,7 +277,7 @@ public class DocumentStyleImpl {
     if (ret == null) {
       Element e = DOM.createElement(tagName);
       Document.get().getBody().appendChild(e);
-      ret = curCSS(e, "display", false);
+      ret = curCSS(e, DISPLAY, false);
       e.removeFromParent();
       if (ret == null || ret.matches("(|none)")) {
         ret = "block";

--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/impl/SelectorEngineCssToXPath.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/impl/SelectorEngineCssToXPath.java
@@ -37,6 +37,8 @@ import java.util.ArrayList;
  */
 public class SelectorEngineCssToXPath extends SelectorEngineImpl {
 
+  private static final String SELF = "/self::";
+
   static JsNamedArray<String> cache;
 
   /**
@@ -90,7 +92,7 @@ public class SelectorEngineCssToXPath extends SelectorEngineImpl {
         return s1;
       }
       if ("even".equals(s2)) {
-        return prefix + "[position() mod 2=0 and position()>=0]" + (noPrefix ? "" : "/self::" + s1);
+        return prefix + "[position() mod 2=0 and position()>=0]" + (noPrefix ? "" : SELF + s1);
       }
       if ("odd".equals(s2)) {
         prefix = afterAttr ? prefix : noPrefix ? "" : s1;
@@ -98,14 +100,14 @@ public class SelectorEngineCssToXPath extends SelectorEngineImpl {
       }
 
       if (!s2.contains("n")) {
-        return prefix + "[position() = " + s2 + "]" + (noPrefix ? "" : "/self::" + s1);
+        return prefix + "[position() = " + s2 + "]" + (noPrefix ? "" : SELF + s1);
       }
 
       String[] t = s2.replaceAll("^([0-9]*)n.*?([0-9]*)?$", "$1+$2").split("\\+");
       String t0 = t[0];
       String t1 = t.length > 1 ? t[1] : "0";
       return prefix + "[(position()-" + t1 + ") mod " + t0 + "=0 and position()>=" + t1 + "]"
-          + (noPrefix ? "" : "/self::" + s1);
+          + (noPrefix ? "" : SELF + s1);
     }
   };
 

--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/impl/research/SelectorEngineJS.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/impl/research/SelectorEngineJS.java
@@ -37,6 +37,9 @@ import com.google.gwt.query.client.js.JsUtils;
  */
 public class SelectorEngineJS extends SelectorEngineImpl {
 
+  private static final String LINE_BEGINNING_OR_WHITESPACE_CHARACTER = "(^|\\s)";
+  private static final String WHITESPACE_CHARACTER_OR_LINR_END = "(\\s|$)";
+
   /**
    * Internal class.
    */
@@ -312,7 +315,7 @@ public class SelectorEngineJS extends SelectorEngineImpl {
             String nextTagStr = null;
             if (JsUtils.truth(nextTag)) {
               nextTagStr = nextTag.get(0);
-              nextRegExp = new JsRegexp("(^|\\s)" + nextTagStr + "(\\s|$)", "i");
+              nextRegExp = new JsRegexp(LINE_BEGINNING_OR_WHITESPACE_CHARACTER + nextTagStr + WHITESPACE_CHARACTER_OR_LINR_END, "i");
             }
             for (int j = 0, jlen = prevElem.size(); j < jlen; j++) {
               Node prevRef = prevElem.getNode(j);
@@ -381,7 +384,7 @@ public class SelectorEngineJS extends SelectorEngineImpl {
             JsRegexp[] regExpClassNames = new JsRegexp[allClasses.length];
             for (int n = 0, nl = allClasses.length; n < nl; n++) {
               regExpClassNames[n] = new JsRegexp(
-                  "(^|\\s)" + allClasses[n] + "(\\s|$)");
+                  LINE_BEGINNING_OR_WHITESPACE_CHARACTER + allClasses[n] + WHITESPACE_CHARACTER_OR_LINR_END);
             }
             JsNodeArray matchingClassElms = JsNodeArray.create();
             for (int o = 0, olen = prevElem.size(); o < olen; o++) {
@@ -646,10 +649,10 @@ public class SelectorEngineJS extends SelectorEngineImpl {
       JsObjectArray<String> notAttr = new JsRegexp(
           "\\[(\\w+)(\\^|\\$|\\*|\\||~)?=?([\\w\\u00C0-\\uFFFF\\s\\-_\\.]+)?\\]")
           .exec(pseudoValue);
-      JsRegexp notRegExp = new JsRegexp("(^|\\s)"
+      JsRegexp notRegExp = new JsRegexp(LINE_BEGINNING_OR_WHITESPACE_CHARACTER
           + (JsUtils.truth(notTag) ? notTag.get(1)
               : JsUtils.truth(notClass) ? notClass.get(1) : "")
-          + "(\\s|$)", "i");
+          + WHITESPACE_CHARACTER_OR_LINR_END, "i");
       if (JsUtils.truth(notAttr)) {
         String notAttribute = JsUtils.truth(notAttr.get(3)) ? notAttr
             .get(3).replace("\\.", "\\.") : null;

--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/plugins/UiPlugin.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/plugins/UiPlugin.java
@@ -65,10 +65,13 @@ public class UiPlugin extends GQuery {
 
   private static class GQueryUiImpl {
 
+    private static final String ABSOLUTE = "absolute";
+    private static final String POSITION = "position";
+
     public GQuery scrollParent(final UiPlugin gQueryUi) {
       GQuery scrollParent;
 
-      if ("fixed".equals(gQueryUi.css("position", false))) {
+      if ("fixed".equals(gQueryUi.css(POSITION, false))) {
         return GQuery.$(getViewportElement());
       }
 
@@ -77,9 +80,9 @@ public class UiPlugin extends GQuery {
 
           public boolean f(Element e, int index) {
             GQuery g = GQuery.$(e);
-            String position = g.css("position", true);
-            return ("relative".equals(position) || "absolute".equals(position) || "fixed"
-                .equals(position))
+            String positionLocal = g.css(POSITION, true);
+            return ("relative".equals(positionLocal) || ABSOLUTE.equals(positionLocal) || "fixed"
+                .equals(positionLocal))
                 && isOverflowEnabled(g);
           }
         });
@@ -96,7 +99,7 @@ public class UiPlugin extends GQuery {
     }
 
     protected boolean scrollParentPositionTest(UiPlugin gQueryUi) {
-      return "absolute".equals(gQueryUi.css("position"));
+      return ABSOLUTE.equals(gQueryUi.css(POSITION));
     }
 
     private Element getViewportElement() {
@@ -116,9 +119,9 @@ public class UiPlugin extends GQuery {
 
     @Override
     protected boolean scrollParentPositionTest(UiPlugin gQueryUi) {
-      String position = gQueryUi.css("position", false);
-      return ("absolute".equals(position) || "relative".equals(position) || "static"
-          .equals(position));
+      String positionLocal = gQueryUi.css("position", false);
+      return ("absolute".equals(positionLocal) || "relative".equals(positionLocal) || "static"
+          .equals(positionLocal));
     }
   }
 

--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/plugins/ajax/Ajax.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/plugins/ajax/Ajax.java
@@ -49,8 +49,8 @@ import com.google.gwt.user.client.ui.FormPanel;
  */
 public class Ajax extends GQuery {
 
+  private static final String JSONP = "jsonp";
   public static final String JSON_CONTENT_TYPE = "application/json";
-
   public static final String JSON_CONTENT_TYPE_UTF8 = JSON_CONTENT_TYPE + "; charset=utf-8";
 
   /**
@@ -176,7 +176,7 @@ public class Ajax extends GQuery {
 
     Promise ret = null;
 
-    if ("jsonp".equalsIgnoreCase(dataType)) {
+    if (JSONP.equalsIgnoreCase(dataType)) {
       ret = GQ.getAjaxTransport().getJsonP(settings);
     } else if ("loadscript".equalsIgnoreCase(dataType)) {
       ret = GQ.getAjaxTransport().getLoadScript(settings);
@@ -235,7 +235,7 @@ public class Ajax extends GQuery {
     if (settings.getType() != null) {
       type = settings.getType().toUpperCase();
     }
-    if ("jsonp".equalsIgnoreCase(settings.getDataType())) {
+    if (JSONP.equalsIgnoreCase(settings.getDataType())) {
       type = "GET";
     }
     settings.setType(type);
@@ -351,7 +351,7 @@ public class Ajax extends GQuery {
   public static Promise getJSONP(String url, IsProperties data, Function onSuccess) {
     Settings s = createSettings();
     s.setUrl(url);
-    s.setDataType("jsonp");
+    s.setDataType(JSONP);
     s.setType("get");
     s.setData(data);
     s.setSuccess(onSuccess);
@@ -361,7 +361,7 @@ public class Ajax extends GQuery {
   public static Promise getJSONP(String url, Function success, Function error, int timeout) {
     return ajax(createSettings()
         .setUrl(url)
-        .setDataType("jsonp")
+        .setDataType(JSONP)
         .setType("get")
         .setTimeout(timeout)
         .setSuccess(success)

--- a/gwtquery-core/src/main/java/com/google/gwt/query/client/plugins/effects/ClipAnimation.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/client/plugins/effects/ClipAnimation.java
@@ -26,6 +26,8 @@ import com.google.gwt.query.client.plugins.Effects.GQAnimation;
  */
 public class ClipAnimation extends PropertiesAnimation {
 
+  private static final String POSITION = "position";
+
   /**
    * Type of the effect action.
    */
@@ -48,7 +50,7 @@ public class ClipAnimation extends PropertiesAnimation {
   }
 
   private static final String[] attrsToSave = new String[] {
-      "position", "overflow", "visibility", "white-space", "top", "left", "width", "height"};
+      POSITION, "overflow", "visibility", "white-space", "top", "left", "width", "height"};
 
   private Action action;
   private Corner corner;
@@ -106,7 +108,7 @@ public class ClipAnimation extends PropertiesAnimation {
     g.saveCssAttrs(attrsToSave);
 
     // CSS clip only works with absolute/fixed positioning
-    if (!g.css("position", true).matches("absolute|fixed")) {
+    if (!g.css(POSITION, true).matches("absolute|fixed")) {
       // Add a temporary element to replace the original one, so nothing is moved when
       // setting the absolute  position to our element
       back = back.add(g.before("<div></div>")).prev();
@@ -117,7 +119,7 @@ public class ClipAnimation extends PropertiesAnimation {
       g.css("left", g.offset().left + "px");
       g.css("width", g.width() + "px");
       g.css("height", g.height() + "px");
-      g.css("position", "absolute");
+      g.css(POSITION, "absolute");
     }
     g.css("overflow", "hidden");
     g.css("visivility", "visible");

--- a/gwtquery-core/src/main/java/com/google/gwt/query/rebind/JsonBuilderGenerator.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/rebind/JsonBuilderGenerator.java
@@ -51,6 +51,9 @@ import java.util.Set;
  */
 public class JsonBuilderGenerator extends Generator {
 
+  private static final String DOUBLE_QUOTATION_MARK_COMMA = "\", a);";
+  private static final String RETURN = "return ";
+
   static JClassType functionType;
   static JClassType jsonBuilderType;
   static JClassType settingsType;
@@ -183,10 +186,10 @@ public class JsonBuilderGenerator extends Generator {
         sw.println("return p.getStr(\"" + name + "\");");
       } else if (isTypeAssignableTo(method.getReturnType(), jsonBuilderType)) {
         String q = method.getReturnType().getQualifiedSourceName();
-        sw.println("return " + "getIsPropertiesBase(getPropertiesBase(\"" + name + "\")," + q + ".class);");
+        sw.println(RETURN + "getIsPropertiesBase(getPropertiesBase(\"" + name + "\")," + q + ".class);");
       } else if (isTypeAssignableTo(method.getReturnType(), settingsType)) {
         String q = method.getReturnType().getQualifiedSourceName();
-        sw.println("return " + "((" + q + ")getPropertiesBase(\"" + name + "\"));");
+        sw.println(RETURN + "((" + q + ")getPropertiesBase(\"" + name + "\"));");
       } else if (retType.equals(Properties.class.getName())) {
         sw.println("return getPropertiesBase(\"" + name + "\");");
       } else if (isTypeAssignableTo(method.getReturnType(), jsType)) {
@@ -207,12 +210,12 @@ public class JsonBuilderGenerator extends Generator {
           ret = "getArrayBase(\"" + name + "\", new " + t + "[l], " + t + ".class)";
         }
         if (arr != null) {
-          sw.println("return " + ret + ";");
+          sw.println(RETURN + ret + ";");
         } else {
           sw.println("return Arrays.asList(" + ret + ");");
         }
       } else if (method.getReturnType().isEnum() != null) {
-        sw.println("return " + method.getReturnType().getQualifiedSourceName()
+        sw.println(RETURN + method.getReturnType().getQualifiedSourceName()
             + ".valueOf(p.getStr(\"" + name + "\"));");
       } else {
         sw.println("System.err.println(\"JsonBuilderGenerator WARN: unknown return type "
@@ -243,16 +246,16 @@ public class JsonBuilderGenerator extends Generator {
           .getParameterizedQualifiedSourceName()
           .matches(
               "(java.lang.(Character|Long|Double|Integer|Float|Byte)|(char|long|double|int|float|byte))")) {
-        sw.println("p.setNumber(\"" + name + "\", a);");
+        sw.println("p.setNumber(\"" + name + DOUBLE_QUOTATION_MARK_COMMA);
       } else if (type.getParameterizedQualifiedSourceName().matches("(java.lang.Boolean|boolean)")) {
-        sw.println("p.setBoolean(\"" + name + "\", a);");
+        sw.println("p.setBoolean(\"" + name + DOUBLE_QUOTATION_MARK_COMMA);
       } else if (type.getParameterizedQualifiedSourceName().matches(
           "com.google.gwt.query.client.Function")) {
-        sw.println("p.setFunction(\"" + name + "\", a);");
+        sw.println("p.setFunction(\"" + name + DOUBLE_QUOTATION_MARK_COMMA);
       } else if (type.isEnum() != null) {
         sw.println("p.set(\"" + name + "\", a.name());");
       } else {
-        sw.println("set(\"" + name + "\", a);");
+        sw.println("set(\"" + name + DOUBLE_QUOTATION_MARK_COMMA);
       }
       if (!"void".equals(retType)) {
         if (isTypeAssignableTo(method.getReturnType(),
@@ -328,7 +331,7 @@ public class JsonBuilderGenerator extends Generator {
     sw.println("}");
     sw.println("public " + IsProperties.class.getName() + " create() {");
     sw.indent();
-    sw.println("return " + Properties.class.getName() + ".create();");
+    sw.println(RETURN + Properties.class.getName() + ".create();");
     sw.outdent();
     sw.println("}");
   }

--- a/gwtquery-core/src/main/java/com/google/gwt/query/rebind/SelectorGeneratorBase.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/rebind/SelectorGeneratorBase.java
@@ -34,6 +34,8 @@ import java.io.PrintWriter;
  */
 public abstract class SelectorGeneratorBase extends Generator {
 
+  private static final String RETURN = "return ";
+
   protected JClassType nodeType = null;
 
   private TreeLogger treeLogger;
@@ -92,19 +94,19 @@ public abstract class SelectorGeneratorBase extends Generator {
 
     if (sel != null && sel.value().matches("^#\\w+$")) {
       // short circuit #foo
-      sw.println("return "
+      sw.println(RETURN
           + wrap(method, "JsNodeArray.create(((Document)root).getElementById(\""
               + sel.value().substring(1) + "\"))") + ";");
     } else if (sel != null && sel.value().matches("^\\w+$")) {
       // short circuit FOO
-      sw.println("return "
+      sw.println(RETURN
           + wrap(method,
               "JsNodeArray.create(((Element)root).getElementsByTagName(\""
                   + sel.value() + "\"))") + ";");
     } else if (sel != null && sel.value().matches("^\\.\\w+$")
         && hasGetElementsByClassName()) {
       // short circuit .foo for browsers with native getElementsByClassName
-      sw.println("return "
+      sw.println(RETURN
           + wrap(method, "JsNodeArray.create(getElementsByClassName(\""
               + sel.value().substring(1) + "\", root))") + ";");
     } else {

--- a/gwtquery-core/src/main/java/com/google/gwt/query/rebind/SelectorGeneratorNative.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/rebind/SelectorGeneratorNative.java
@@ -27,6 +27,9 @@ import com.google.gwt.user.rebind.SourceWriter;
  */
 public class SelectorGeneratorNative extends SelectorGeneratorCssToXPath {
 
+  private static final String DOUBLE_QUOTATION_MARK_COMMA = "\", root)";
+  private static final String RETURN = "return ";
+
   @Override
   protected void generateMethodBody(SourceWriter sw, JMethod method,
       TreeLogger treeLogger, boolean hasContext)
@@ -34,24 +37,24 @@ public class SelectorGeneratorNative extends SelectorGeneratorCssToXPath {
 
     String selector = method.getAnnotation(Selector.class).value();
     if (selector.matches("#[\\w\\-]+")) {
-      sw.println("return "
-          + wrap(method, "veryQuickId(\"" + selector.substring(1) + "\", root)") + ";");
+      sw.println(RETURN
+          + wrap(method, "veryQuickId(\"" + selector.substring(1) + DOUBLE_QUOTATION_MARK_COMMA) + ";");
     } else if (selector.equals("*") || selector.matches("[\\w\\-]+")) {
-      sw.println("return "
-          + wrap(method, "elementsByTagName(\"" + selector + "\", root)") + ";");
+      sw.println(RETURN
+          + wrap(method, "elementsByTagName(\"" + selector + DOUBLE_QUOTATION_MARK_COMMA) + ";");
     } else if (selector.matches("\\.[\\w\\-]+")) {
-      sw.println("return "
-          + wrap(method, "elementsByClassName(\"" + selector.substring(1) + "\", root)") + ";");
+      sw.println(RETURN
+          + wrap(method, "elementsByClassName(\"" + selector.substring(1) + DOUBLE_QUOTATION_MARK_COMMA) + ";");
     } else if (selector.contains("!=")) {
-      sw.println("return "
+      sw.println(RETURN
           + wrap(method, "querySelectorAll(\""
               + selector.replaceAll("(\\[\\w+)!(=[^\\]]+\\])", ":not($1$2)")
-              + "\", root)") + ";");
+              + DOUBLE_QUOTATION_MARK_COMMA) + ";");
     } else if (selector.matches(SelectorEngineNative.NATIVE_EXCEPTIONS_REGEXP)) {
       super.generateMethodBody(sw, method, treeLogger, hasContext);
     } else {
-      sw.println("return "
-          + wrap(method, "querySelectorAll(\"" + selector + "\", root)") + ";");
+      sw.println(RETURN
+          + wrap(method, "querySelectorAll(\"" + selector + DOUBLE_QUOTATION_MARK_COMMA) + ";");
     }
   }
 

--- a/gwtquery-core/src/main/java/com/google/gwt/query/rebind/SelectorGeneratorNativeIE8.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/rebind/SelectorGeneratorNativeIE8.java
@@ -27,25 +27,28 @@ import com.google.gwt.user.rebind.SourceWriter;
  */
 public class SelectorGeneratorNativeIE8 extends SelectorGeneratorJS {
 
+  private static final String DOUBLE_QUOTATION_MARK_COMMA = "\", root)";
+  private static final String RETURN = "return ";
+
   @Override
   protected void generateMethodBody(SourceWriter sw, JMethod method,
       TreeLogger treeLogger, boolean hasContext)
       throws UnableToCompleteException {
     String selector = method.getAnnotation(Selector.class).value();
     if (selector.matches("#[\\w\\-]+")) {
-      sw.println("return "
-          + wrap(method, "veryQuickId(\"" + selector.substring(1) + "\", root)") + ";");
+      sw.println(RETURN
+          + wrap(method, "veryQuickId(\"" + selector.substring(1) + DOUBLE_QUOTATION_MARK_COMMA) + ";");
     } else if (selector.equals("*") || selector.matches("[\\w\\-]+")) {
-      sw.println("return "
-          + wrap(method, "elementsByTagName(\"" + selector + "\", root)") + ";");
+      sw.println(RETURN
+          + wrap(method, "elementsByTagName(\"" + selector + DOUBLE_QUOTATION_MARK_COMMA) + ";");
     } else if (selector.matches("\\.[\\w\\-]+")) {
-      sw.println("return "
-          + wrap(method, "elementsByClassName(\"" + selector.substring(1) + "\", root)") + ";");
+      sw.println(RETURN
+          + wrap(method, "elementsByClassName(\"" + selector.substring(1) + DOUBLE_QUOTATION_MARK_COMMA) + ";");
     } else if (selector.matches(SelectorEngineNativeIE8.NATIVE_EXCEPTIONS_REGEXP)) {
       super.generateMethodBody(sw, method, treeLogger, hasContext);
     } else {
-      sw.println("return "
-          + wrap(method, "querySelectorAll(\"" + selector + "\", root)") + ";");
+      sw.println(RETURN
+          + wrap(method, "querySelectorAll(\"" + selector + DOUBLE_QUOTATION_MARK_COMMA) + ";");
     }
   }
 

--- a/gwtquery-core/src/main/java/com/google/gwt/query/rebind/SelectorGeneratorNativeIE9.java
+++ b/gwtquery-core/src/main/java/com/google/gwt/query/rebind/SelectorGeneratorNativeIE9.java
@@ -27,25 +27,28 @@ import com.google.gwt.user.rebind.SourceWriter;
  */
 public class SelectorGeneratorNativeIE9 extends SelectorGeneratorJS {
 
+  private static final String DOUBLE_QUOTATION_MARK_COMMA = "\", root)";
+  private static final String RETURN = "return ";
+
   @Override
   protected void generateMethodBody(SourceWriter sw, JMethod method,
       TreeLogger treeLogger, boolean hasContext)
       throws UnableToCompleteException {
     String selector = method.getAnnotation(Selector.class).value();
     if (selector.matches("#[\\w\\-]+")) {
-      sw.println("return "
-          + wrap(method, "veryQuickId(\"" + selector.substring(1) + "\", root)") + ";");
+      sw.println(RETURN
+          + wrap(method, "veryQuickId(\"" + selector.substring(1) + DOUBLE_QUOTATION_MARK_COMMA) + ";");
     } else if (selector.equals("*") || selector.matches("[\\w\\-]+")) {
-      sw.println("return "
-          + wrap(method, "elementsByTagName(\"" + selector + "\", root)") + ";");
+      sw.println(RETURN
+          + wrap(method, "elementsByTagName(\"" + selector + DOUBLE_QUOTATION_MARK_COMMA) + ";");
     } else if (selector.matches("\\.[\\w\\-]+")) {
-      sw.println("return "
-          + wrap(method, "elementsByClassName(\"" + selector.substring(1) + "\", root)") + ";");
+      sw.println(RETURN
+          + wrap(method, "elementsByClassName(\"" + selector.substring(1) + DOUBLE_QUOTATION_MARK_COMMA) + ";");
     } else if (selector.matches(SelectorEngineNative.NATIVE_EXCEPTIONS_REGEXP)) {
       super.generateMethodBody(sw, method, treeLogger, hasContext);
     } else {
-      sw.println("return "
-          + wrap(method, "querySelectorAll(\"" + selector + "\", root)") + ";");
+      sw.println(RETURN
+          + wrap(method, "querySelectorAll(\"" + selector + DOUBLE_QUOTATION_MARK_COMMA) + ";");
     }
   }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1192 String literals should not be duplicated.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1192
Please let me know if you have any questions.
George Kankava

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/arcbees/gwtquery/376)
<!-- Reviewable:end -->
