### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Currently, almost the jQuery API is written and all CSS3 selectors should be sup
 We are working in a brand new web site, in the meanwhile for more information/documentation
 visit gQuery wiki pages at : https://code.google.com/p/gwtquery/
 
-##Thanks to
+## Thanks to
 [![Arcbees.com](http://i.imgur.com/HDf1qfq.png)](http://arcbees.com)
 
 [![Vaadin.com](https://rawgit.com/manolo/vaadin-stuff/master/vaadin-ui.png)](http://vaadin.com)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/arcbees/gwtquery/384)
<!-- Reviewable:end -->
